### PR TITLE
ci: add syntax-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Syntax check (ESM sources)
+        run: |
+          for f in $(find src -name '*.js'); do
+            echo "node --check $f"
+            node --check "$f"
+          done


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — the repo had no CI (top MISSING_CI item on the fleet repo-scan).

**On push to main + every PR:**
- `npm ci` — install + lockfile integrity
- `node --check` on each ESM file under `src/` (index, client, commands)

Kept minimal on purpose: there's no eslint config and `npm test` is the default stub (`exit 1`), so a syntax gate is what passes green today. Verified locally against current `main` — all three files check clean and `npm ci` exits 0. Easy to extend once a real test suite exists.